### PR TITLE
Refactor OpenAPI document fetching with validation

### DIFF
--- a/docs/src/lib/openapi.ts
+++ b/docs/src/lib/openapi.ts
@@ -1,5 +1,29 @@
+import type { OpenAPIV3_2 } from "fumadocs-openapi";
 import { createOpenAPI } from "fumadocs-openapi/server";
 
+const openApiDocumentUrl = "https://api.lurkr.gg/v2/docs/json";
+
+async function fetchOpenAPIDocument(): Promise<OpenAPIV3_2.Document> {
+	const response = await fetch(openApiDocumentUrl);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch OpenAPI document from ${openApiDocumentUrl}: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const contentType = response.headers.get("content-type") ?? "";
+	if (!contentType.includes("json")) {
+		throw new Error(`Expected JSON from ${openApiDocumentUrl}, received content-type "${contentType}"`);
+	}
+
+	const document: unknown = await response.json();
+	if (typeof document !== "object" || document === null || !("openapi" in document)) {
+		throw new Error(`Response from ${openApiDocumentUrl} is not an OpenAPI document`);
+	}
+
+	return document as OpenAPIV3_2.Document;
+}
+
 export const openapi = createOpenAPI({
-	input: ["https://api.lurkr.gg/v2/docs/json"],
+	input: { lurkr: fetchOpenAPIDocument },
 });


### PR DESCRIPTION
## Summary
Refactored the OpenAPI document loading to fetch from a remote URL with proper error handling and validation, rather than passing the URL directly to `createOpenAPI`.

## Changes
- Extracted OpenAPI document fetching into a dedicated `fetchOpenAPIDocument()` function with comprehensive error handling
- Added validation for HTTP response status, content-type header, and document structure
- Updated `createOpenAPI` configuration to use the async fetch function instead of a raw URL string
- Added proper TypeScript typing with `OpenAPIV3_2.Document` type

## Implementation Details
The new `fetchOpenAPIDocument()` function:
- Validates HTTP response status and throws descriptive errors on failure
- Checks that the response content-type includes "json"
- Validates the response structure contains an "openapi" field before casting
- Provides clear error messages for debugging at each validation step

https://claude.ai/code/session_01VVGWDFhFS3uJqQtgoEnaRs