### PR TITLE
perf: limit Open Sans to the Latin subset

### DIFF
--- a/dash/src/app/fonts.ts
+++ b/dash/src/app/fonts.ts
@@ -10,5 +10,6 @@ export const openSans = Open_Sans({
 		"Segoe UI Symbol",
 		"Noto Color Emoji",
 	],
+	subsets: ["latin"],
 	variable: "--font-sans",
 });

--- a/docs/src/app/fonts.ts
+++ b/docs/src/app/fonts.ts
@@ -11,5 +11,6 @@ export const openSans = Open_Sans({
 		"Segoe UI Symbol",
 		"Noto Color Emoji",
 	],
+	subsets: ["latin"],
 	variable: "--font-sans",
 });


### PR DESCRIPTION
## Summary

- Limit Open Sans to the Latin subset in the dashboard and documentation apps.
- Reduce unnecessary font loading for supported pages.

## Testing

- Not run (font configuration-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font loading consistency by explicitly configuring the Latin character subset for Open Sans across the application and documentation sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->